### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved
+
+# Xcode
+xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+
+# macOS
+.DS_Store
+
+# CocoaPods (keeping original project structure)
+SDK/Pods/
+SDK/Podfile.lock
+
+# Original Xcode workspace files
+SDK/*.xcworkspace/xcuserdata/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "StarPRNTSDK",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "StarPRNTSDK",
+            targets: ["StarPRNTSDK"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "StarPRNTSDK",
+            dependencies: [
+                "StarIO",
+                "StarIO_Extension"
+            ],
+            path: "Sources/StarPRNTSDK",
+            publicHeadersPath: "."
+        ),
+        .binaryTarget(
+            name: "StarIO",
+            path: "SDK/Pods/StarIO/StarIO.xcframework"
+        ),
+        .binaryTarget(
+            name: "StarIO_Extension",
+            path: "SDK/Pods/StarIO_Extension/StarIO_Extension.xcframework"
+        )
+    ]
+)

--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,29 @@ StarIO, StarIO_Extension, uses User defaults APIs. StarIODeviceSetting does not 
 
 Please refer to the [StarPRNT SDK document](https://www.star-m.jp/starprntsdk-oml-ios.html) for supported OS, development environment, and supported printers.
 
+## Installation
+
+### Swift Package Manager
+
+You can add StarPRNT SDK to your project using Swift Package Manager.
+
+1. In Xcode, go to **File > Add Package Dependencies...**
+2. Enter the repository URL: `https://github.com/star-micronics/StarPRNT-SDK-iOS-Swift`
+3. Select the version or branch you want to use
+4. Click **Add Package**
+
+Or add it to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/star-micronics/StarPRNT-SDK-iOS-Swift.git", from: "5.20.1")
+]
+```
+
+### CocoaPods
+
+Please refer to the existing documentation for CocoaPods installation instructions.
+
 ## important
 
 ### Considerations when using mC-Label2

--- a/Sources/StarPRNTSDK/StarPRNTSDK.swift
+++ b/Sources/StarPRNTSDK/StarPRNTSDK.swift
@@ -1,0 +1,12 @@
+//
+//  StarPRNTSDK.swift
+//  StarPRNT SDK
+//
+//  This file re-exports the StarIO frameworks for Swift Package Manager
+//
+
+import Foundation
+
+// Re-export the frameworks so users only need to import StarPRNTSDK
+@_exported import StarIO
+@_exported import StarIO_Extension


### PR DESCRIPTION
- Add Package.swift configuration for SPM
- Reference existing XCFrameworks from Pods directory
- Create StarPRNTSDK wrapper module for clean imports
- Update README with SPM installation instructions
- Add .gitignore for SPM build artifacts

Users can now add the SDK via Swift Package Manager using the GitHub URL.